### PR TITLE
Fix: Support AS users on Sync endpoint

### DIFF
--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -1709,36 +1709,30 @@ class RoomEventSource(EventSource[RoomStreamToken, EventBase]):
             logger.warning("Stream has topological part!!!! %r", from_key)
             from_key = RoomStreamToken(stream=from_key.stream)
 
-        app_service = self.store.get_app_service_by_user_id(user.to_string())
-        if app_service:
-            # We no longer support AS users using /sync directly.
-            # See https://github.com/matrix-org/matrix-doc/issues/1144
-            raise NotImplementedError()
-        else:
-            room_events = await self.store.get_membership_changes_for_user(
+        room_events = await self.store.get_membership_changes_for_user(
                 user.to_string(), from_key, to_key
             )
 
-            room_to_events = await self.store.get_room_events_stream_for_rooms(
-                room_ids=room_ids,
-                from_key=from_key,
-                to_key=to_key,
-                limit=limit or 10,
-                order="ASC",
-            )
+        room_to_events = await self.store.get_room_events_stream_for_rooms(
+                    room_ids=room_ids,
+                    from_key=from_key,
+                    to_key=to_key,
+                    limit=limit or 10,
+                    order="ASC",
+                )
 
-            events = list(room_events)
-            events.extend(e for evs, _ in room_to_events.values() for e in evs)
+        events = list(room_events)
+        events.extend(e for evs, _ in room_to_events.values() for e in evs)
 
-            events.sort(key=lambda e: e.internal_metadata.order)
+        events.sort(key=lambda e: e.internal_metadata.order)
 
-            if limit:
-                events[:] = events[:limit]
+        if limit:
+            events[:] = events[:limit]
 
-            if events:
-                end_key = events[-1].internal_metadata.after
-            else:
-                end_key = to_key
+        if events:
+            end_key = events[-1].internal_metadata.after
+        else:
+            end_key = to_key
 
         return events, end_key
 

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1379,11 +1379,11 @@ class SyncHandler:
         """
 
         user_id = sync_config.user.to_string()
-        app_service = self.store.get_app_service_by_user_id(user_id)
-        if app_service:
-            # We no longer support AS users using /sync directly.
-            # See https://github.com/matrix-org/matrix-doc/issues/1144
-            raise NotImplementedError()
+        # app_service = self.store.get_app_service_by_user_id(user_id)
+        # if app_service:
+        #     # We no longer support AS users using /sync directly.
+        #     # See https://github.com/matrix-org/matrix-doc/issues/1144
+        #     raise NotImplementedError()
 
         # Note: we get the users room list *before* we get the current token, this
         # avoids checking back in history if rooms are joined after the token is fetched.

--- a/synapse/rest/client/filter.py
+++ b/synapse/rest/client/filter.py
@@ -84,8 +84,6 @@ class CreateFilterRestServlet(RestServlet):
         target_user = UserID.from_string(user_id)
         requester = await self.auth.get_user_by_req(request)
 
-        logger.info("[DEBUG]: Creating filter for %s, %s", target_user, requester)
-
         if target_user != requester.user:
             raise AuthError(403, "Cannot create filters for other users")
 

--- a/synapse/rest/client/filter.py
+++ b/synapse/rest/client/filter.py
@@ -84,6 +84,8 @@ class CreateFilterRestServlet(RestServlet):
         target_user = UserID.from_string(user_id)
         requester = await self.auth.get_user_by_req(request)
 
+        logger.info("[DEBUG]: Creating filter for %s, %s", target_user, requester)
+
         if target_user != requester.user:
             raise AuthError(403, "Cannot create filters for other users")
 


### PR DESCRIPTION
This pull request includes changes to remove unnecessary code that checks if the user is an app service user in two different files: `synapse/handlers/room.py` and `synapse/handlers/sync.py`.

Main changes:

* [`synapse/handlers/room.py`](diffhunk://#diff-93fd6bbc57a34580e9fb4a475130f1cc255707f6e5771fad0bf4abe6f169838cL1712-L1717): Removed the check for app service users from the `get_new_events` function.
* [`synapse/handlers/sync.py`](diffhunk://#diff-70c84622edff898486bdc02d7a579db4e52a3e0b26c14020bed0ca1fb8ea2018L1382-R1386): Commented out the code that checks if the user is an app service user in the `generate_sync_result` function.